### PR TITLE
Use `request.Host` for the issuer hostname

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -54,11 +54,6 @@ resource "google_cloud_run_service" "issuer" {
       service_account_name = google_service_account.issuer.email
       containers {
         image = ko_image.image.image_ref
-        env {
-          name = "ISSUER_URL"
-          # Until b/267200341 is fixed, we need this... :(
-          value = "https://justtrustme.dev"
-        }
       }
     }
   }

--- a/main.go
+++ b/main.go
@@ -72,9 +72,7 @@ type TokenResponse struct {
 }
 
 func issuer(r *http.Request) string {
-	// For whatever reason, Cloud Run is not setting the Host header,
-	// so we need this until b/267200341 is fixed.
-	return os.Getenv("ISSUER_URL")
+	return fmt.Sprintf("https://%s", r.Host)
 }
 
 func main() {


### PR DESCRIPTION
This makes it so that anyone can deploy their own to Cloud Run and things should "just work" with the automatic Cloud Run hostnames! 