### PR TITLE
Add simple embedded map encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,26 @@ Interesting endpoints:
 - [/](https://justtrustme.dev/)
 - [/token](https://justtrustme.dev/token)
 - [/token?aud=sts.amazonaws.com&likes_dogs=true&debug=true](https://justtrustme.dev/token?aud=sts.amazonaws.com&likes_dogs=true&debug=true)
+- [/token?foo=bar&MAP:embedded=key1=value1,key2=value2&debug=true"](https://justtrustme.dev/token?foo=bar&MAP:embedded=key1=value1,key2=value2&debug=true)
 - [/keys](https://justtrustme.dev/keys)
 - [/.well-known/openid-configuration](https://justtrustme.dev/.well-known/openid-configuration)
 
 `?debug=true` is a special query arg that will render a decoded token.
+
+Keys prefixed with `MAP:` is a special query arg that will allow for embedded
+simple string=>string structures as embedded claims. For example, if you wanted
+to provide foo=>bar as claim, but also a struct called embedded with
+key1=>value1 and key2=>value2 that would then look like this:
+
+```
+	"payload": {
+		"embedded": {
+			"key1": "value1",
+			"key2": "value2"
+		},
+		"exp": 1680895833,
+		"foo": "bar"
+    }
+```
+
+You would use this: `/token?foo=bar&MAP:embedded=key1=value1,key2=value2`


### PR DESCRIPTION
Thought about adding these as base64 encoded but wanted to keep the simple syntax and playground format, so felt this achieved both.

Here's the example invocation:
```
vaikas@vaikas-MBP justtrustme % curl 'http://localhost:8080/token?foo=bar&MAP:embedded=key1=value1,key2=value2&debug=true'
{
	"header": {
		"alg": "RS256",
		"kid": "110124d5-5776-47e2-b106-c2f3ae6e876c"
	},
	"payload": {
		"embedded": {
			"key1": "value1",
			"key2": "value2"
		},
		"exp": 1680895833,
		"foo": "bar",
		"iat": 1680894033,
		"iss": "https://localhost:8080"
	},
	"signature": "ScbX9jDO5cI1hUaMf9Z9ULrvXQs1beDDPAlGP4TWHF8F19Y3cj2MEMMRO_PidkctpIhJu0ODe2bFDDsdDoMohNW-Yzdfpcr4_Eq3Xag6tm4TI208eM5wcHmXICsBClHJ29FqDqrFiGxBPGtXeW7XpGHH26rHmAipofd0j2HorrcI33QQDnQyYrv272f3rBpDxWYHoLr_q84fzQlckXJHF5wijVjaMxy199HKNwfcmUoGzNnDFAI_u2HewSwHHmH4pmqH1wJpGFQcjsqpOk6n5u9MGNLiHJ6JTsPbwqAkMzX7PxBWZ3P1TyvsY92qTvXsxfD8oAOUtEXMPJfKzfb4Ew"
}
```