### PR TITLE
Add support for POST & embedded claims struct in the body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # justtrustme
 
-justtrust me is a demo/testing OIDC token issuer. It will accept any claims as query parameters and mint valid OIDC tokens with them.
+justtrust me is a demo/testing OIDC token issuer. It will accept any claims as
+query parameters (or POST body using JSON encoding) and mint valid OIDC tokens
+with them.
 
 Needless to say, __do not trust anything about this__.
 
@@ -13,3 +15,22 @@ Interesting endpoints:
 - [/.well-known/openid-configuration](https://justtrustme.dev/.well-known/openid-configuration)
 
 `?debug=true` is a special query arg that will render a decoded token.
+
+You can also POST a JSON struct that contains the keys. This allows for embedded
+queries for example. As an example:
+`curl -X POST 'https://justtrustme.dev/token?debug=true&foo=bar' -d '{"key1":"value1","embedded":{"key2":"value2","key3":"value3"}}'`
+
+Would create the following claims:
+```
+	"payload": {
+		"embedded": {
+			"key2": "value2",
+			"key3": "value3"
+		},
+		"exp": 1680999300,
+		"foo": "bar",
+		"iat": 1680997500,
+		"iss": "https://justtrustme.dev",
+		"key1": "value1"
+	}
+```

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -133,6 +134,24 @@ func main() {
 		query := r.URL.Query()
 		debug := query.Get("debug")
 		claims := make(map[string]interface{})
+
+		// This is fine even if there's no to body sent.
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Errorf("error reading body: %w", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if len(body) > 0 {
+			err = json.Unmarshal(body, &claims)
+			if err != nil {
+				log.Errorf("error unmarshaling: %w", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
 		for k, v := range query {
 			if k == "debug" {
 				continue


### PR DESCRIPTION
Instead of screwing around with encodings, just support POSTing a body where you can just add the struct you want directly. Simple invocation.

```vaikas@vaikas-MBP justtrustme % curl -X POST 'localhost:8080/token?debug=true&foo=bar' -d '{"key1":"value1","embedded":{"key2":"value2","key3":"value3"}}'
{
	"header": {
		"alg": "RS256",
		"kid": "f290f230-6b31-4ec2-86bd-b8c5e2c01c82"
	},
	"payload": {
		"embedded": {
			"key2": "value2",
			"key3": "value3"
		},
		"exp": 1680999300,
		"foo": "bar",
		"iat": 1680997500,
		"iss": "https://localhost:8080",
		"key1": "value1"
	},
```