### PR TITLE
fix(ci): add zizmor pedantic persona and suppress noisy findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,13 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 3
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 3
   open-pull-requests-limit: 10

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zizmor configuration for justtrustme.
+# CI runs zizmor with --pedantic; rules with no security value are disabled
+# to keep CI signal-to-noise high. See PSEC-923 for rationale.
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  # Pedantic-only; low security value but extremely noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This single-patch series adds the `persona: pedantic` configuration to the
zizmor CI workflow and suppresses noisy pedantic-only rules with no direct
security value. A Dependabot cooldown of 3 days is also configured.

## Patches

### 0001 — fix(ci): add pedantic persona and suppress noisy zizmor rules

Adds `.github/zizmor.yml` with the following configuration:

- `dependabot-cooldown: config: days: 3` — sets the expected minimum cooldown
  (2 findings: gomod + github-actions ecosystems had no cooldown configured)
- `anonymous-definition: disable: true` — pedantic-only, purely cosmetic
  (2 findings suppressed)
- `concurrency-limits: disable: true` — pedantic-only, low security value
  (4 findings suppressed)

Updates `.github/dependabot.yml` to add `cooldown: default-days: 3` to both
the gomod and github-actions update blocks.

Updates `.github/workflows/zizmor.yaml` to:
- Pass `--pedantic` to zizmor-action
- Extend the `paths:` trigger to include `.github/dependabot.yml` and
  `.github/zizmor.yml`

## Findings addressed

| Rule | Count | Disposition |
|------|-------|-------------|
| `concurrency-limits` | 4 | Disabled in zizmor.yml (low security value) |
| `anonymous-definition` | 2 | Disabled in zizmor.yml (no security impact) |
| `dependabot-cooldown` | 2 | cooldown: default-days: 3 added to dependabot.yml |

## Testing

After merging, open a PR that modifies `.github/dependabot.yml` or
`.github/zizmor.yml` to verify the paths trigger fires. The zizmor check
should pass with zero findings.

Refs: PSEC-923